### PR TITLE
feat: recent/popular/unreadページにコミュニティ情報表示機能を追加

### DIFF
--- a/plugins/nodebb-plugin-caiz/library.js
+++ b/plugins/nodebb-plugin-caiz/library.js
@@ -34,6 +34,7 @@ plugin.init = async function (params) {
 plugin.customizeCategoriesLink = Community.customizeIndexLink;
 plugin.customizeCategoryLink = Category.customizeLink;
 plugin.customizeTopicRender = Topic.customizeRender;
+plugin.filterTopicsBuild = Community.filterTopicsBuild;
 plugin.customizeSidebarCommunities = Header.customizeSidebarCommunities;
 plugin.loadCommunityEditModal = Header.loadCommunityEditModal;
 

--- a/plugins/nodebb-plugin-caiz/libs/community.js
+++ b/plugins/nodebb-plugin-caiz/libs/community.js
@@ -147,6 +147,11 @@ class Community extends Base {
   static async createCommunityGroup(name, description, ownerUid, privateFlag, hidden) {
     return community.createCommunityGroup(name, description, ownerUid, privateFlag, hidden);
   }
+
+  // Filter method for topics build
+  static async filterTopicsBuild(hookData) {
+    return community.filterTopicsBuild(hookData);
+  }
 }
 
 module.exports = Community;

--- a/plugins/nodebb-plugin-caiz/libs/community/index.js
+++ b/plugins/nodebb-plugin-caiz/libs/community/index.js
@@ -43,5 +43,6 @@ module.exports = {
   // Helper operations
   getCommunity: helpers.getCommunity,
   customizeIndexLink: helpers.customizeIndexLink,
-  createCommunityLink: helpers.createCommunityLink
+  createCommunityLink: helpers.createCommunityLink,
+  filterTopicsBuild: core.filterTopicsBuild
 };

--- a/plugins/nodebb-plugin-caiz/plugin.json
+++ b/plugins/nodebb-plugin-caiz/plugin.json
@@ -59,6 +59,18 @@
     {
       "hook": "filter:post.create",
       "method": "filterPostCreate"
+    },
+    {
+      "hook": "filter:recent.build",
+      "method": "filterTopicsBuild"
+    },
+    {
+      "hook": "filter:popular.build", 
+      "method": "filterTopicsBuild"
+    },
+    {
+      "hook": "filter:unread.build",
+      "method": "filterTopicsBuild"
     }
   ]
 }

--- a/plugins/nodebb-theme-caiz/templates/partials/topics_list.tpl
+++ b/plugins/nodebb-theme-caiz/templates/partials/topics_list.tpl
@@ -20,6 +20,18 @@
 				{{{ end }}}
 			</div>
 			<div class="flex-grow-1 d-flex flex-wrap gap-1 position-relative">
+				{{{ if ./community }}}
+					<a href="{config.relative_path}/{./community.handle}" class="badge fw-normal text-decoration-none text-reset d-inline-flex align-items-center gap-1" style="font-size: larger">
+						{{{ if ./community.image }}}
+						<img src="{./community.image}" alt="{./community.name}" class="rounded-1" style="width: 16px; height: 16px; object-fit: cover;">
+						{{{ else }}}
+						{{{ if ./community.icon }}}
+						<i class="fa {./community.icon}" style="color: {./community.color}; width: 16px; height: 16px; font-size: 16px; display: inline-flex; align-items: center; justify-content: center;"></i>
+						{{{ end }}}
+						{{{ end }}}
+						<span>{./community.name}</span>
+					</a>
+				{{{ end }}}
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>


### PR DESCRIPTION
- filter:recent.build, filter:popular.build, filter:unread.buildフックを追加
- トピック一覧にコミュニティ名とアイコン/画像をバッジ形式で表示
- 画像設定済みコミュニティは画像を優先表示、未設定時はFontAwesomeアイコン
- コミュニティ名クリックで該当コミュニティページに遷移
- アイコンと画像のサイズを16px×16pxで統一

🤖 Generated with [Claude Code](https://claude.ai/code)