### PR TITLE
fix: categoriesページのカテゴリアイテムから余計なborderを削除

### DIFF
--- a/.tmp/tasks.md
+++ b/.tmp/tasks.md
@@ -49,6 +49,8 @@
 - [x] /communities を2列表示に（画面幅による）
 - [x] /communities ではMarkdown禁止に
 
+- [ ] categories/categoryに余計なborderがついているので削除
+
 # 第2フェーズ
 
 - MCPサーバー

--- a/plugins/nodebb-theme-caiz/templates/partials/categories/item.tpl
+++ b/plugins/nodebb-theme-caiz/templates/partials/categories/item.tpl
@@ -1,4 +1,4 @@
-<div component="categories/category" data-cid="{./cid}" class="w-100 border rounded-3 p-3 h-100 d-flex flex-column category-{./cid} {./unread-class}">
+<div component="categories/category" data-cid="{./cid}" class="w-100 p-3 h-100 d-flex flex-column category-{./cid} {./unread-class}">
 	<meta itemprop="name" content="{./name}">
 
 	<div class="d-flex flex-grow-1 gap-2 gap-lg-3">


### PR DESCRIPTION
- カテゴリアイテムの `border rounded-3` クラスを削除してクリーンな見た目に改善

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed unintended border and rounded corners from category tiles, resulting in a cleaner, flatter appearance.
  - Improves visual consistency across the categories grid without affecting behavior or data.

- **Documentation**
  - Added a Phase 2 checklist item to remove the extra border on category components.
  - Clarifies the UI cleanup task; no functional changes introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->