### PR TITLE
feat: 自動翻訳機能の包括的改善とトピック一覧翻訳対応

### DIFF
--- a/plugins/nodebb-plugin-auto-translate/lib/translation/prompt-manager.js
+++ b/plugins/nodebb-plugin-auto-translate/lib/translation/prompt-manager.js
@@ -16,29 +16,19 @@ class PromptManager {
      */
     buildTranslationPrompt(content, settings) {
         try {
-            const systemPrompt = settings?.prompts?.systemPrompt || 
-                'You are a professional localization translator.';
+            if (!settings?.prompts?.translationPrompt) {
+                throw new Error('Translation prompt not configured in settings');
+            }
             
-            const prompt = `${systemPrompt}
-
-Task:
-Translate the given SOURCE text into the following 20 languages and return ONLY a single JSON object with exactly these keys:
-["en","zh-CN","hi","es","ar","fr","bn","ru","pt","ur","id","de","ja","fil","tr","ko","fa","sw","ha","it"]
-
-Requirements:
-- Preserve meaning, tone, and register; produce idiomatic, natural sentences.
-- Keep placeholders, variables, code, and markdown as-is (e.g., {name}, {{variable}}, \`code\`, URLs).
-- Don't add explanations, notes, or extra fields.
-- Don't transliterate brand names unless there is a widely used localized form.
-- If the source contains line breaks, keep them logically.
-- If a translation is truly not applicable, return an empty string "" for that key.
-
-Now translate this SOURCE:
-${content}`;
+            // Use the configured translation prompt and replace placeholders
+            const prompt = settings.prompts.translationPrompt
+                .replace('{content}', content)
+                .replace('{supportedLanguages}', JSON.stringify(this.supportedLanguages));
             
-            winston.verbose('[auto-translate] Built multi-language prompt:', {
+            winston.verbose('[auto-translate] Built translation prompt from settings:', {
                 contentLength: content.length,
-                languageCount: this.supportedLanguages.length
+                languageCount: this.supportedLanguages.length,
+                promptLength: prompt.length
             });
             
             return prompt;

--- a/plugins/nodebb-plugin-auto-translate/plugin.json
+++ b/plugins/nodebb-plugin-auto-translate/plugin.json
@@ -41,6 +41,14 @@
     {
       "hook": "filter:topic.build",
       "method": "filterTopicBuild"
+    },
+    {
+      "hook": "filter:category.topics.get",
+      "method": "filterCategoryTopicsGet"
+    },
+    {
+      "hook": "filter:homepage.build",
+      "method": "filterHomepageBuild"
     }
   ],
   "templates": "./templates",


### PR DESCRIPTION
## Summary
自動翻訳機能の大幅改善とトピック一覧での翻訳表示機能を実装

## Changes

### 🔧 翻訳プロンプト管理改善
- **設定ベースプロンプト**: ハードコードされたフォールバック除去、管理画面で完全制御
- **フォーマット保持強化**: 改行、リスト、段落構造の保持を明確指示
- **エラーハンドリング**: 設定未定義時の明確なエラー表示

### 🌐 トピック一覧翻訳対応
- **カテゴリーページ**: `filter:category.topics.get`フックでトピックタイトル翻訳
- **ホームページ**: `filter:homepage.build`フックでトピックタイトル翻訳
- **オリジナル表示ボタン不要**: 一覧表示では翻訳のみ

### 🔨 技術的改善
- **Markdown/HTMLパース**: 翻訳コンテンツの正しいパース処理
- **詳細ログ**: デバッグ情報の大幅強化
- **エラー処理**: 翻訳失敗時のフォールバック改善
- **コードクリーンアップ**: 重複コード除去と構造最適化

### 🐛 バグ修正
- **Gemini APIトークン制限**: maxTokens 8192 → 32768
- **JSONパースエラー**: 応答途切れ問題の解決
- **改行消失**: 翻訳時のフォーマット保持問題解決

## Test plan
- [x] 長い投稿の翻訳が正常動作
- [x] 改行・リスト構造が保持される
- [x] カテゴリーページでタイトル翻訳表示
- [x] ホームページでタイトル翻訳表示
- [x] 設定画面でプロンプト管理
- [x] エラーハンドリングが適切に動作

🤖 Generated with [Claude Code](https://claude.ai/code)