### PR TITLE
Fix bug

### DIFF
--- a/plugins/nodebb-plugin-auto-translate/lib/translation/prompt-manager.js
+++ b/plugins/nodebb-plugin-auto-translate/lib/translation/prompt-manager.js
@@ -16,12 +16,12 @@ class PromptManager {
      */
     buildTranslationPrompt(content, settings) {
         try {
-            if (!settings?.prompts?.translationPrompt) {
-                throw new Error('Translation prompt not configured in settings');
+            if (!settings?.prompts?.systemPrompt) {
+                throw new Error('System prompt not configured in settings');
             }
             
-            // Use the configured translation prompt and replace placeholders
-            const prompt = settings.prompts.translationPrompt
+            // Use the configured system prompt and replace placeholders
+            const prompt = settings.prompts.systemPrompt
                 .replace('{content}', content)
                 .replace('{supportedLanguages}', JSON.stringify(this.supportedLanguages));
             


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Prompt construction now derives from the System Prompt setting; placeholders for content and supported languages remain supported. Public interface unchanged. No changes to how translations are triggered.

- Bug Fixes
  - When the System Prompt is missing, the plugin now shows a clearer configuration error instead of a generic translation prompt error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->