### PR TITLE
feat: OAuth 2.0 Resource Server Metadataエンドポイントを実装

### DIFF
--- a/plugins/nodebb-plugin-mcp-server/routes/mcp.js
+++ b/plugins/nodebb-plugin-mcp-server/routes/mcp.js
@@ -131,32 +131,5 @@ module.exports = function(router) {
         });
     });
 
-    /**
-     * OAuth 2.0 Resource Server Metadata endpoint
-     * GET /.well-known/oauth-protected-resource
-     */
-    router.get('/.well-known/oauth-protected-resource', (req, res) => {
-        try {
-            winston.verbose('[mcp-server] Resource server metadata requested');
-            
-            // RFC 8414準拠のリソースサーバーメタデータを返す
-            // 実装は次のフェーズで追加予定
-            // const ResourceServerMetadata = require('../lib/metadata');
-            // const metadata = ResourceServerMetadata.getMetadata();
-            // res.json(metadata);
-            
-            res.status(501).json({
-                error: 'not_implemented',
-                error_description: 'OAuth 2.0 Resource Server Metadata endpoint is not yet implemented'
-            });
-        } catch (err) {
-            winston.error('[mcp-server] Resource server metadata error:', err);
-            res.status(500).json({
-                error: 'server_error',
-                error_description: 'Internal server error while generating metadata'
-            });
-        }
-    });
-
     return router;
 };


### PR DESCRIPTION
- lib/metadata.js: RFC 8414準拠のメタデータ生成クラス実装
- /.well-known/oauth-protected-resource エンドポイントをルートレベルに追加
- NodeBB設定から直接URLを取得（フォールバックなし）
- 適切なCORSヘッダーとキャッシュ制御を設定
- 設定検証機能とエラーハンドリングを実装

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a standards-compliant OAuth 2.0 Resource Metadata endpoint at /.well-known/oauth-protected-resource, exposing supported scopes and related details.
  - Enables CORS and sets caching headers for broader accessibility and improved performance.
- Bug Fixes
  - Replaces the previous placeholder with fully functional metadata generation and configuration validation.
  - Returns clear server_error responses for misconfiguration or internal failures.
- Refactor
  - Removes the legacy route variant and consolidates the metadata endpoint at the well-known path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->