### PR TITLE
feat: OAuth2 Device Authorization Grant Token Endpoint実装

### DIFF
--- a/plugins/nodebb-plugin-mcp-server/lib/oauth-token.js
+++ b/plugins/nodebb-plugin-mcp-server/lib/oauth-token.js
@@ -402,7 +402,7 @@ class OAuthToken {
         if (deviceData.status === 'token_issued') {
             winston.warn('[mcp-server] Device code already used', { device_code: device_code.substring(0, 8) + '...' });
             const error = new Error('Device code has already been used');
-            error.code = 'access_denied';
+            error.code = 'invalid_grant';
             throw error;
         }
 


### PR DESCRIPTION
RFC 8628準拠のPOST /oauth/tokenエンドポイントを実装
- Device Authorization Grant (urn:ietf:params:oauth:grant-type:device_code)
- Authorization Code Grant (authorization_code) との併用サポート

## 実装内容

### lib/oauth-token.js
- exchangeDeviceCodeForToken(): デバイスコードをトークンに交換
- generateDeviceTokens(): アクセストークン・リフレッシュトークン生成
- refreshDeviceAccessToken(): リフレッシュトークンローテーション
- validateDeviceAccessToken(): トークン検証
- _generateSecureToken(): 暗号学的に安全なトークン生成
- _hashToken(): SHA-256ハッシュ計算（平文保存回避）

### routes/oauth.js
- POST /oauth/token エンドポイント拡張
- grant_type による分岐処理
- RFC 8628準拠エラーハンドリング
- Retry-After ヘッダー対応（slow_down）
- セキュリティヘッダー設定

## RFC 8628準拠機能
- ポーリング間隔制御・バックオフ
- デバイスコード状態管理（pending/approved/denied/token_issued）
- クライアント認証・一致検証
- 競合制御による一意トークン発行
- 適切なHTTPステータス・エラーコード

## セキュリティ対策
- トークンハッシュ保存（平文回避）
- リフレッシュトークンローテーション
- 暗号学的に安全な乱数生成
- TTL管理・自動期限切れ処理

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added device authorization (RFC 8628) support: device-code grant, token issuance, refresh/rotation, and access-token validation.

- Improvements
  - Standardized OAuth2/RFC 8628 error responses and HTTP statuses (including authorization_pending, access_denied, invalid_grant, slow_down).
  - Added Retry-After handling for slow_down and consistent no-store/cache headers on success and error; enhanced logging of grant_type and client_id.

- Refactor
  - Unified and consolidated token endpoint error handling and response formatting for predictable API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->