### PR TITLE
fix(extra-renderer): MathJaxコードブロックのレンダリングを修正

### DIFF
--- a/plugins/nodebb-plugin-extra-renderer/static/extra-renderer.js
+++ b/plugins/nodebb-plugin-extra-renderer/static/extra-renderer.js
@@ -256,6 +256,32 @@
       });
     });
 
+    // Find all Math code blocks
+    const mathBlocks = document.querySelectorAll('code.language-math');
+    console.log('[extra-renderer] Found math blocks:', mathBlocks.length);
+    
+    mathBlocks.forEach((codeEl) => {
+      if (codeEl.dataset.mathProcessed) return;
+      codeEl.dataset.mathProcessed = '1';
+      
+      console.log('[extra-renderer] Processing math block');
+      const code = codeEl.textContent || codeEl.innerText;
+      const preEl = codeEl.parentElement;
+      
+      // Replace the pre/code block with math container
+      const container = document.createElement('div');
+      container.className = 'math-container';
+      container.style.cssText = 'margin: 1em 0; text-align: center;';
+      
+      preEl.parentNode.insertBefore(container, preEl);
+      preEl.remove();
+      
+      renderMathCode(code, container).catch(err => {
+        console.error('[extra-renderer] Math async render error:', err);
+        container.innerHTML = `<pre>Math async error: ${err?.message || 'Unknown error'}</pre>`;
+      });
+    });
+
     // Find all paragraphs and check for special content
     const allParagraphs = document.querySelectorAll('p');
     console.log('[extra-renderer] Found paragraphs:', allParagraphs.length);


### PR DESCRIPTION
- code.language-mathセレクタのサポートを追加
- MathJaxレンダリング処理を専用コードブロックに対応

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for rendering math code blocks (language: math) directly in posts.
  - Automatic, per-block processing prevents duplicate renders.
  - Displays a clear message if math rendering fails.

- Style
  - Rendered math appears centered in a dedicated container for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->