### PR TITLE
fix(x-oauth-ui): always attempt window.close() even without opener; l…

### DIFF
--- a/plugins/nodebb-plugin-caiz/libs/x-notification/controllers.js
+++ b/plugins/nodebb-plugin-caiz/libs/x-notification/controllers.js
@@ -61,7 +61,8 @@ controllers.handleOAuthCallback = async (req, res) => {
                   window.opener.postMessage({ type: 'x-auth-success', accountId: '${accountData.accountId}', screenName: 'Connected Account' }, '*');
                   try { window.close(); } catch (e) {}
                 } else {
-                  // No opener – show completion message
+                  // No opener – attempt to close, then show completion message if still open
+                  try { window.close(); } catch (e) {}
                   document.body.innerHTML = '<p>Connection successful. You may close this window.</p>';
                 }
               } catch (e) {


### PR DESCRIPTION
…eave completion message as fallback if browser blocks close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - OAuth認証後の完了画面で、ポップアップに親ウィンドウがない場合でも自動的に閉じるよう試行するよう改善しました。これにより、no‑opener環境で不要なウィンドウが残りにくくなります。
  - 親ウィンドウがある場合の挙動（メッセージ送信後にウィンドウを閉じる）は従来通り動作し、完了までの体験がより一貫しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->