### PR TITLE
fix(x-notification): X通知システムを共通通知設定アーキテクチャに修正

### DIFF
--- a/plugins/nodebb-plugin-caiz/libs/x-notification/x-config.js
+++ b/plugins/nodebb-plugin-caiz/libs/x-notification/x-config.js
@@ -14,12 +14,6 @@ xConfig.getConfig = async (cid) => {
     enabled: await meta.settings.getOne('caiz', `${settingsPrefix}enabled`) === 'true',
     selectedAccountId: await meta.settings.getOne('caiz', `${settingsPrefix}selectedAccountId`),
     accounts: [],
-    events: {
-      newTopic: await meta.settings.getOne('caiz', `${settingsPrefix}events:newTopic`) === 'true',
-      newPost: await meta.settings.getOne('caiz', `${settingsPrefix}events:newPost`) === 'true',
-      memberJoin: await meta.settings.getOne('caiz', `${settingsPrefix}events:memberJoin`) === 'true',
-      memberLeave: await meta.settings.getOne('caiz', `${settingsPrefix}events:memberLeave`) === 'true'
-    },
     templates: {
       newTopic: await meta.settings.getOne('caiz', `${settingsPrefix}templates:newTopic`),
       newPost: await meta.settings.getOne('caiz', `${settingsPrefix}templates:newPost`),
@@ -49,12 +43,6 @@ xConfig.updateConfig = async (cid, updates) => {
     await meta.settings.setOne('caiz', `${settingsPrefix}selectedAccountId`, updates.selectedAccountId);
   }
   
-  // Update events
-  if (updates.events) {
-    for (const [key, value] of Object.entries(updates.events)) {
-      await meta.settings.setOne('caiz', `${settingsPrefix}events:${key}`, value.toString());
-    }
-  }
   
   // Update templates
   if (updates.templates) {

--- a/plugins/nodebb-plugin-caiz/libs/x-notification/x-notifier.js
+++ b/plugins/nodebb-plugin-caiz/libs/x-notification/x-notifier.js
@@ -16,10 +16,17 @@ xNotifier.notifyNewTopic = async (topicData) => {
       return;
     }
     
-    // Get X notification config
-    const config = await xConfig.getConfig(community.cid);
-    winston.info(`[x-notification] Config for community ${community.cid}: enabled=${config.enabled}, newTopic=${config.events.newTopic}`);
-    if (!config.enabled || !config.events.newTopic) {
+    // Get X connection config (for enabled status)
+    const xConnConfig = await xConfig.getConfig(community.cid);
+    if (!xConnConfig.enabled) {
+      winston.info(`[x-notification] X notifications disabled for community ${community.cid}`);
+      return;
+    }
+    
+    // Get common notification settings (same as Slack/Discord)
+    const communitySlackSettings = require('../community-slack-settings');
+    const notificationSettings = await communitySlackSettings.getNotificationSettings(community.cid);
+    if (!notificationSettings || notificationSettings.enabled === false || !notificationSettings.newTopic) {
       winston.info(`[x-notification] New topic notification disabled for community ${community.cid}`);
       return;
     }
@@ -63,9 +70,17 @@ xNotifier.notifyNewPost = async (postData) => {
       return;
     }
     
-    // Get X notification config
-    const config = await xConfig.getConfig(community.cid);
-    if (!config.enabled || !config.events.newPost) {
+    // Get X connection config (for enabled status)
+    const xConnConfig = await xConfig.getConfig(community.cid);
+    if (!xConnConfig.enabled) {
+      winston.info(`[x-notification] X notifications disabled for community ${community.cid}`);
+      return;
+    }
+    
+    // Get common notification settings (same as Slack/Discord)
+    const communitySlackSettings = require('../community-slack-settings');
+    const notificationSettings = await communitySlackSettings.getNotificationSettings(community.cid);
+    if (!notificationSettings || notificationSettings.enabled === false || !notificationSettings.newPost) {
       winston.info(`[x-notification] New post notification disabled for community ${community.cid}`);
       return;
     }


### PR DESCRIPTION
- X専用のconfig.eventsではなく、Slack/Discordと同じ共通通知設定を使用
- communitySlackSettings.getNotificationSettings()で通知イベント設定を取得
- X configからeventsプロパティを削除（Xは接続管理のみ）
- これにより全プラットフォーム（Slack/Discord/X）でコミュニティレベルの共通通知設定が実現

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- リファクタ
  - X通知の有効判定を一元の通知設定に統合し、新規トピック/投稿の送信可否を同設定のフラグで制御。
  - 旧「イベント」設定（newTopic/newPost/memberJoin/memberLeave）の読み込み・保存を廃止。
- 雑務
  - 不要なログを削除し、無効時のログ出力を整理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->