### PR TITLE
docs(tasks): Task 50 - SSE with API token

### DIFF
--- a/.tmp/tasks.md
+++ b/.tmp/tasks.md
@@ -201,8 +201,11 @@
   - [x] 46: 規約モーダル表示トリガー 設計ドキュメント作成（.tmp/tasks/task-46-consent-modal-trigger.md）
   - [x] div.topic-info のカテゴリー名が多言語処理されていない
   - [x] 47: div.topic-info カテゴリー名 i18n 設計ドキュメント作成（.tmp/tasks/task-47-topic-info-category-i18n.md）
-  - [ ] html lang 属性が多言語処理されていない
+  - [x] html lang 属性が多言語処理されていない
 - MCP機能 ver2
+- [ ] 50: APIトークンでもSSE接続できるようにする 設計ドキュメント作成（.tmp/tasks/task-50-sse-with-api-token.md）
+  - [ ] 詳細な検索条件のサポート（カテゴリー、タグ、投稿ユーザー、日付範囲）
+  - [ ] 特定のコミュニティ・カテゴリー以下に投稿できるようにする
   - [ ] レート制限
     - `POST /mcp/messages` に rps 制限
   - [ ] 逆プロキシ前提のヘッダ/タイムアウト

--- a/.tmp/tasks/task-50-sse-with-api-token.md
+++ b/.tmp/tasks/task-50-sse-with-api-token.md
@@ -1,14 +1,15 @@
 # 50: APIトークンによるSSE接続
 
-- [ ] ドキュメントレビュー完了（レビュー後に実装着手）
+- [ ] ドキュメントレビュー完了
 
 ## 概要
 - 目的: APIトークン（ユーザーが発行したPersonal Access Token等）を用いて、`GET /api/mcp` のSSE接続を確立できるようにする。
-- 対象: `nodebb-plugin-mcp-server`（実装は本PRでは行わない）。
+- 対象: `nodebb-plugin-mcp-server`
 - 範囲: 認可ヘッダの受理、トークン検証、ユーザー識別、SSE開始までの認可フロー。UI変更やトークン発行機能の拡張は対象外。
 
 ## 要件
 - 認証方式: `Authorization: Bearer <api_token>` を受理し、既存のBearer/OAuth2と共存。
+  - APIトークンの発行、管理機能はすでに実装されているものを利用
 - 同一ユーザー識別: 検証後に `uid`, `scopes`, `tokenId` 等をSSEコンテキストへ設定。
 - フォールバック禁止: トークン欠落・不正・期限切れ・権限不足は明確に401/403を返す（擬似成功なし）。
 - ヘッダ: `text/event-stream`, `Cache-Control: no-store`, `Connection: keep-alive` 等は既存方針に準拠。

--- a/.tmp/tasks/task-50-sse-with-api-token.md
+++ b/.tmp/tasks/task-50-sse-with-api-token.md
@@ -1,0 +1,55 @@
+# 50: APIトークンによるSSE接続
+
+- [ ] ドキュメントレビュー完了（レビュー後に実装着手）
+
+## 概要
+- 目的: APIトークン（ユーザーが発行したPersonal Access Token等）を用いて、`GET /api/mcp` のSSE接続を確立できるようにする。
+- 対象: `nodebb-plugin-mcp-server`（実装は本PRでは行わない）。
+- 範囲: 認可ヘッダの受理、トークン検証、ユーザー識別、SSE開始までの認可フロー。UI変更やトークン発行機能の拡張は対象外。
+
+## 要件
+- 認証方式: `Authorization: Bearer <api_token>` を受理し、既存のBearer/OAuth2と共存。
+- 同一ユーザー識別: 検証後に `uid`, `scopes`, `tokenId` 等をSSEコンテキストへ設定。
+- フォールバック禁止: トークン欠落・不正・期限切れ・権限不足は明確に401/403を返す（擬似成功なし）。
+- ヘッダ: `text/event-stream`, `Cache-Control: no-store`, `Connection: keep-alive` 等は既存方針に準拠。
+
+## インタフェース（英語／宣言のみ）
+```ts
+export interface SseAuthContext {
+  uid: number;
+  tokenId?: string;
+  scopes: string[];
+}
+
+export interface ApiTokenInfo {
+  uid: number;
+  tokenId: string;
+  scopes: string[];
+  active: boolean;
+  expiresAt?: number; // epoch ms
+}
+
+export interface ApiTokenValidator {
+  // Validate bearer token string and return token info
+  validate(token: string): Promise<ApiTokenInfo>;
+}
+
+export interface SseAuthorizer {
+  // Build auth context from request (supports API token + OAuth2)
+  authorize(req: import('http').IncomingMessage): Promise<SseAuthContext>;
+}
+
+export interface SseConnection {
+  // Start SSE stream for authorized user context
+  start(res: import('http').ServerResponse, ctx: SseAuthContext): void;
+}
+```
+
+## 受け入れ基準
+- 有効なAPIトークンを持つユーザーが、`Authorization: Bearer` で `GET /api/mcp` に接続しSSEを受信できること。
+- 無効・失効・権限不足のトークンでは401/403で接続が拒否されること。
+- 既存のBearer/OAuth2フローを破壊せず共存できること（デグレなし）。
+
+## 備考
+- 実装時は既存の簡易認証レイヤーにAPIトークン検証を組み込み、分岐のみで構成する（関数シグネチャは変更しない）。
+- ログには `uid`, `tokenId`（あれば）を含め、監査可能性を確保する。


### PR DESCRIPTION
このPRでは、APIトークンによるSSE接続に関する設計ドキュメントのみを追加しました。\n\n- タスク: 50 APIトークンでもSSE接続できるようにする\n- ファイル: .tmp/tasks/task-50-sse-with-api-token.md\n- 実装は本PRでは行いません。ドキュメント確認後に実装に入ります。\n\n変更点:\n- .tmp/tasks.md にタスク50を追記\n- .tmp/tasks/task-50-sse-with-api-token.md を追加（日本語ドキュメント、コードは英語でインタフェース宣言のみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ドキュメント
  - APIトークンによるSSE接続の設計ドキュメントを追加し、認可フロー、エラー応答（無効/期限切れ/スコープ不足）の扱い、既存認証との共存、SSE応答ヘッダや運用上の振る舞いを明確化しました。
- 雑務
  - タスク「html lang 属性が多言語処理されていない」を完了に更新しました。
  - 「MCP機能 ver2」に新規タスク「APIトークンでもSSE接続できるようにする（設計作成）」と、詳細検索条件・特定コミュニティ/カテゴリー下投稿のサブタスクを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->